### PR TITLE
WordDegree and WordFrequency ranking metrics added

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,3 +19,6 @@ travis-ci = { repository = "yaa110/rake-rs" }
 regex = "1.4"
 serde = { version = "1.0", features = ["derive"] }
 lazy_static = "1.4"
+
+[dev-dependencies]
+assert_approx_eq = "1.1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,7 +48,9 @@ mod inner;
 mod keyword;
 mod rake;
 mod stopwords;
+mod metric;
 
 pub use self::rake::Rake;
 pub use keyword::{KeywordScore, KeywordSort};
 pub use stopwords::StopWords;
+pub use metric::Metric;

--- a/src/metric.rs
+++ b/src/metric.rs
@@ -1,0 +1,14 @@
+use serde::{Deserialize, Serialize};
+
+/// Ranking metric
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub enum Metric {
+    /// d(w)/f(w) (Default metric) Ratio of degree of word to its frequency.
+    DegreeToFrequencyRatio,
+
+    /// d(w) Degree of word only. 
+    WordDegree,
+
+    /// f(w) Frequency of word only.
+    WordFrequency,
+}

--- a/tests/rake_test.rs
+++ b/tests/rake_test.rs
@@ -1,21 +1,72 @@
-use rake::{KeywordScore, Rake, StopWords};
+use rake::{KeywordScore, Rake, StopWords, Metric};
+use assert_approx_eq::assert_approx_eq;
 
 #[test]
 fn test_score() {
     let text = "Compatibility of systems of linear constraints over the set of natural numbers. Criteria of compatibility of a system of linear Diophantine equations, strict inequations, and nonstrict inequations are considered. Upper bounds for components of a minimal set of solutions and algorithms of construction of minimal generating sets of solutions for all types of systems are given. These criteria and the corresponding algorithms for constructing a minimal supporting set of solutions can be used in solving all the considered types of systems and systems of mixed types.";
     let sw = StopWords::from_file("tests/SmartStoplist.txt").unwrap();
-    let r = Rake::new(sw);
+    let mut r = Rake::new(sw);
+
+    let print = |keywords: &Vec<KeywordScore>| {
+        keywords.iter().for_each(
+            |&KeywordScore {
+                 ref keyword,
+                 ref score,
+             }| println!("{}: {}", keyword, score),
+        );
+        println!();
+    };
+
+    // default DegreeToFrequencyRatio metric
+
     let keywords = r.run(text);
 
-    keywords.iter().for_each(
-        |&KeywordScore {
-             ref keyword,
-             ref score,
-         }| println!("{}: {}", keyword, score),
-    );
+    print(&keywords);
 
     assert_eq!(keywords[0].keyword, "minimal generating sets");
     assert_eq!(keywords[1].keyword, "linear Diophantine equations");
     assert_eq!(keywords[2].keyword, "minimal supporting set");
     assert_eq!(keywords[3].keyword, "minimal set");
+    assert_approx_eq!(keywords[0].score, 8.666666666666666);
+    assert_approx_eq!(keywords[1].score, 8.5);
+    assert_approx_eq!(keywords[2].score, 7.666666666666666);
+    assert_approx_eq!(keywords[3].score, 4.666666666666666);
+
+    // WordDegree metric
+
+    r.set_metric(Metric::WordDegree);
+
+    let keywords = r.run(text);
+
+    print(&keywords);
+
+    // score of items 1 and 2 is the same so the order is not guaranteed
+    assert_eq!(keywords[0].keyword, "minimal supporting set");
+    assert!(keywords[1].keyword == "minimal set" || keywords[1].keyword == "minimal generating sets");
+    assert!(keywords[2].keyword == "minimal set" || keywords[2].keyword == "minimal generating sets");
+    assert_ne!(keywords[1].keyword, keywords[2].keyword);
+    assert_eq!(keywords[3].keyword, "linear Diophantine equations");
+    assert_approx_eq!(keywords[0].score, 17.0);
+    assert_approx_eq!(keywords[1].score, 14.0);
+    assert_approx_eq!(keywords[2].score, 14.0);
+    assert_approx_eq!(keywords[3].score, 11.0);
+
+    // WordFrequency metric
+
+    r.set_metric(Metric::WordFrequency);
+
+    let keywords = r.run(text);
+
+    print(&keywords);
+
+    // score of items 2 and 3 is the same so the order is not guaranteed
+    assert_eq!(keywords[0].keyword, "minimal supporting set");
+    assert_eq!(keywords[1].keyword, "minimal set");
+    assert!(keywords[2].keyword == "considered types" || keywords[2].keyword == "minimal generating sets");
+    assert!(keywords[3].keyword == "considered types" || keywords[3].keyword == "minimal generating sets");
+    assert_ne!(keywords[2].keyword, keywords[3].keyword);
+    assert_approx_eq!(keywords[0].score, 7.0);
+    assert_approx_eq!(keywords[1].score, 6.0);
+    assert_approx_eq!(keywords[2].score, 5.0);
+    assert_approx_eq!(keywords[3].score, 5.0);
 }


### PR DESCRIPTION
Multiple ranking metrics added, used the same as in the rake-nltk python implementation: https://csurfer.github.io/rake-nltk/_build/html/advanced.html#to-control-the-metric-for-ranking